### PR TITLE
Add keep-alive header for macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const httpGetAsync = async (url, opts) => new Promise((done, reject) => {
 const run = async (opts, root, postcss) => {
   const httpOpts = {
     headers: {
-      'Connection': 'keep-alive',
+      Connection: 'keep-alive',
       'User-Agent': opts.userAgent,
     },
   };

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const httpGetAsync = async (url, opts) => new Promise((done, reject) => {
 const run = async (opts, root, postcss) => {
   const httpOpts = {
     headers: {
+      'Connection': 'keep-alive',
       'User-Agent': opts.userAgent,
     },
   };


### PR DESCRIPTION
On macOS the requests frequently fail (at least 50% of time).

```
Module build failed (from ../../node_modules/postcss-loader/dist/cjs.js):
Error: read ECONNRESET
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:217:20)
```

A random [SO answer](https://stackoverflow.com/a/54306640) suggested this fix without an explanation. I tried it by locally changing the source code and it indeed seems to help. No error for many consecutive tries. WDYT?